### PR TITLE
feat(proxy): improve request handling and error responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ const BASE_URL = "https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoServi
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
-    const allowedPaths = ["/getRestDeInfo", "/getAnniversaryInfo", "/get24DivisionsInfo"];
-
+    const allowedPaths = new Set(["/getRestDeInfo", "/getAnniversaryInfo", "/get24DivisionsInfo"]);
+    
     // Preflight 요청 처리
     if (request.method === "OPTIONS") {
       return new Response(null, {
@@ -13,32 +13,51 @@ export default {
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'GET, OPTIONS',
           'Access-Control-Allow-Headers': '*',
+          'Access-Control-Max-Age': '86400',
         },
       });
     }
 
-    if (allowedPaths.includes(url.pathname)) {
+    if (allowedPaths.has(url.pathname)) {
       const params = url.searchParams;
 
-      if (!params.has("serviceKey")) {
-        params.set("serviceKey", env.datagokr_serviceKey);
+      if (!env.datagokr_serviceKey) {
+        return new Response(JSON.stringify({
+          error: "Missing environment variable",
+          message: "datagokr_serviceKey is not defined in the environment",
+        }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }
 
+      params.set("serviceKey", env.datagokr_serviceKey);
+
       const targetUrl = `${BASE_URL}${url.pathname}?${params.toString()}`;
+
+      const userAgents = [
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.6167.140 Safari/537.36"
+      ];
+      const randomUserAgent = userAgents[Math.floor(Math.random() * userAgents.length)];
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10000); // 10초
 
       try {
         const response = await fetch(targetUrl, {
           method: "GET",
           headers: {
-            'X-Real-IP': request.headers.get('CF-Connecting-IP'),
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
-            'X-Forwarded-For': '',
-            'X-Forwarded-Host': '',
-            'X-Forwarded-Proto': '',
-          }
+            'User-Agent': randomUserAgent,
+          },
+          signal: controller.signal
+
         });
+        clearTimeout(timeout);
 
         const headers = {
+          // 기본 응답이 XML이므로 기본값으로 'application/xml' 사용
           'Content-Type': response.headers.get('content-type') || 'application/xml',
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'GET, OPTIONS',
@@ -51,9 +70,19 @@ export default {
         });
 
       } catch (e) {
-        return new Response(`Fetch Error: ${e.message}`, {
+        console.error("Fetch Error:", e);
+
+        return new Response(JSON.stringify({
+          error: "Fetch Error",
+          message: e.message,
+        }), {
           status: 500,
-          headers: { 'Content-Type': 'text/plain' },
+          headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, OPTIONS',
+            'Access-Control-Allow-Headers': '*',
+          },
         });
       }
     }


### PR DESCRIPTION
- Added Access-Control-Max-Age header to OPTIONS preflight responses for better CORS caching.  
- Changed allowedPaths from array to Set for faster path lookup.  
- Return 500 error with JSON message if datagokr_serviceKey env variable is missing.  
- Randomized User-Agent header from a list of modern browsers to reduce blocking.  
- Implemented fetch timeout using AbortController to prevent hanging requests.  
- Simplified forwarded headers by removing unused ones.  
- Return JSON-formatted error responses with CORS headers on fetch failures and log errors.  
- Default response Content-Type to application/xml if missing from upstream response.